### PR TITLE
README and GoDoc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Failed assertions usually print a diff. Here's an example using `attest.Equal`:
 This module is stable. It supports the [two most recent major
 releases][go-support-policy] of Go.
 
-Within those parameters, `connectproto` follows semantic versioning. No
+Within those parameters, `attest` follows semantic versioning. No
 breaking changes will be made without incrementing the major version.
 
 ## Legal

--- a/attest.go
+++ b/attest.go
@@ -1,7 +1,7 @@
 // Package attest is a small, type-safe library of assertion helpers.
 //
-// Under the hood, attest uses github.com/google/go-cmp/cmp to test equality
-// and diff values. All of attest's assertions work with any cmp.Option.
+// Under the hood, attest uses [cmp] to test equality and diff values. All of
+// attest's assertions work with any [cmp.Option].
 package attest
 
 import (
@@ -72,7 +72,7 @@ func Error(tb TB, err error, opts ...Option) bool {
 }
 
 // ErrorIs asserts that got wraps want, using the same logic as the standard
-// library's errors.Is.
+// library's [errors.Is].
 func ErrorIs(tb TB, got, want error, opts ...Option) bool {
 	tb.Helper()
 	if errors.Is(got, want) {
@@ -220,8 +220,8 @@ func Subsequence[T ~string | ~[]byte](tb TB, got, want T, opts ...Option) bool {
 	return t.Attest()
 }
 
-// A Number is any type whose underlying type is one of Go's built-in integer
-// or float types.
+// A Number is any type whose underlying type is one of Go's built-in integral
+// or floating-point types.
 type Number interface {
 	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
 		~int | ~int8 | ~int16 | ~int32 | ~int64 |

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"go.akshayshah.org/attest"
 )
 
-// logTB implements the portions of the testing.TB interface that attest uses.
+// logTB implements the portions of the [testing.TB] interface that attest uses.
 // It writes assertion failures to stdout.
 type logTB struct{}
 
@@ -30,9 +30,8 @@ func ExampleAllow() {
 		&logTB{},
 		point{1.0, 1.0},
 		point{1.0, 1.0},
-		// Without Allow, the underlying cmp library errors because point has
-		// unexported fields. We could also use Comparer, or we could implement an
-		// Equal method on point.
+		// Without Allow, cmp errors because point has unexported fields. We could
+		// also use [Comparer], or we could implement an Equal method on point.
 		attest.Allow(point{}),
 	)
 	// Output:
@@ -43,9 +42,8 @@ func ExampleComparer() {
 		&logTB{},
 		point{1.0, 1.0},
 		point{1.0, 1.0},
-		// Without Comparer, the underlying cmp library errors because point has
-		// unexported fields. We could also use Allow, or we could implement an
-		// Equal method on point.
+		// Without Comparer, cmp errors because point has unexported fields. We
+		// could also use [Allow], or we could implement an Equal method on point.
 		attest.Comparer(func(left, right point) bool {
 			return left.x == right.x && left.y == right.y
 		}),
@@ -92,7 +90,7 @@ func ExampleOptions() {
 		&logTB{},
 		point{},
 		defaults,       // our defaults
-		attest.Fatal(), // override Continue() from defaults
+		attest.Fatal(), // override Continue from defaults
 	)
 	// Output:
 }

--- a/option.go
+++ b/option.go
@@ -37,7 +37,7 @@ type msgOption struct {
 // make many similar assertions, the additional explanation may clarify the
 // test output.
 //
-// Arguments are passed to fmt.Sprintf for formatting.
+// Arguments are passed to [fmt.Sprintf] for formatting.
 func Sprintf(template string, args ...any) Option {
 	return &msgOption{fmt.Sprintf(template, args...)}
 }
@@ -46,7 +46,7 @@ func Sprintf(template string, args ...any) Option {
 // make many similar assertions, the additional explanation may clarify the
 // test output.
 //
-// Arguments are passed to fmt.Sprint for formatting.
+// Arguments are passed to [fmt.Sprint] for formatting.
 func Sprint(args ...any) Option {
 	return &msgOption{fmt.Sprint(args...)}
 }
@@ -61,7 +61,7 @@ type fatalOption struct {
 
 // Fatal stops the test immediately when an assertion fails. This is the
 // default behavior, but Fatal may still be useful to reverse the effect of
-// Continue.
+// [Continue].
 func Fatal() Option {
 	return &fatalOption{true}
 }
@@ -80,20 +80,21 @@ type cmpOption struct {
 	cmp []cmp.Option
 }
 
-// Cmp configures the underlying equality assertion, if any. See the
-// github.com/google/go-cmp/cmp package documentation for an explanation of the
-// default logic.
+// Cmp configures the underlying equality assertion, if any. See the [cmp]
+// package documentation for an explanation of the default logic.
 //
 // In particular, note that the cmp package's default behavior is to error when
 // comparing structs with unexported fields. If you control the type in
 // question, implement an Equal method and cmp will use it by default. If you
-// don't control the type, use Allow or Comparer. If none of those approaches
-// fit your needs, cmp and its cmpopts subpackage offer many other ways to
+// don't control the type, use [Allow] or [Comparer]. If none of those approaches
+// fit your needs, [cmp] and its [cmpopts] subpackage offer many other ways to
 // relax this safety check.
 //
 // If you're comparing types generated from a Protocol Buffer schema,
-// google.golang.org/protobuf/testing/protocmp's Transform() option
-// safely transforms them to a comparable, diffable type.
+// [protocmp.Transform] safely transforms them to a comparable, diffable type.
+//
+// [protocmp.Transform]: https://pkg.go.dev/google.golang.org/protobuf/testing/protocmp#Transform
+// [cmpopts]: https://pkg.go.dev/github.com/google/go-cmp/cmp/cmpopts
 func Cmp(opts ...cmp.Option) Option {
 	return &cmpOption{opts}
 }
@@ -106,7 +107,7 @@ func Cmp(opts ...cmp.Option) Option {
 // Allow is useful as a quick hack but is usually a bad idea: changes in the
 // internals of some other package may break your tests. If you control the
 // type in question, implement an Equal method instead. If you don't control
-// the type, Comparer is usually safer.
+// the type, [Comparer] is usually safer.
 func Allow(types ...any) Option {
 	for _, typ := range types {
 		if rt := reflect.TypeOf(typ); rt.Kind() != reflect.Struct {


### PR DESCRIPTION
- Fix README reference to wrong library
- Use links in GoDoc

Fixes #11.
