### PR TITLE
Bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.akshayshah.org/attest
 
-go 1.18
+go 1.21
 
 require github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
This library is documented to support the two most recent major releases; https://github.com/akshayjshah/attest?tab=readme-ov-file#status-stable